### PR TITLE
格式及文案小的调整

### DIFF
--- a/frostmourne-common/src/main/java/com/autohome/frostmourne/common/EmailHelper.java
+++ b/frostmourne-common/src/main/java/com/autohome/frostmourne/common/EmailHelper.java
@@ -30,7 +30,7 @@ import com.autohome.frostmourne.common.contract.MailConfig;
 
 public class EmailHelper {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(EmailHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailHelper.class);
 
     public static boolean send(MailConfig mailConfig, List<String> to, String subject, String content, String contentType, List<MimeBodyPart> attachments) {
         Properties properties = new Properties();

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/config/BeanConfig.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/config/BeanConfig.java
@@ -29,7 +29,7 @@ import okhttp3.OkHttpClient;
 @Configuration
 public class BeanConfig {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(BeanConfig.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BeanConfig.class);
 
     @Value("${initial.password}")
     private String initialPassword;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/IndexController.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/IndexController.java
@@ -18,7 +18,7 @@ import com.autohome.frostmourne.monitor.dao.mybatis.frostmourne.repository.IShor
 @Controller
 public class IndexController {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(IndexController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexController.class);
 
     @Resource
     private IShortLinkRepository shortLinkRepository;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/elasticsearch/ElasticsearchSourceManager.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/elasticsearch/ElasticsearchSourceManager.java
@@ -13,11 +13,11 @@ import com.autohome.frostmourne.common.jackson.JacksonUtil;
 
 public class ElasticsearchSourceManager {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSourceManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSourceManager.class);
 
     private ConcurrentHashMap<String, AbstractElasticClientContainer> containerMap;
 
-    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
     public void init() {
         this.containerMap = new ConcurrentHashMap<>();

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/repository/impl/AlarmRepository.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/repository/impl/AlarmRepository.java
@@ -27,7 +27,7 @@ import com.github.pagehelper.PageHelper;
 @Repository
 public class AlarmRepository implements IAlarmRepository {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(AlarmRepository.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlarmRepository.class);
 
     @Resource
     private AlarmDynamicMapper alarmDynamicMapper;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/constant/GlobalConstant.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/constant/GlobalConstant.java
@@ -8,7 +8,7 @@ package com.autohome.frostmourne.monitor.model.constant;
  */
 public class GlobalConstant {
 
-    public final static String LINE_SEPARATOR = System.getProperty("line.separator");
+    public static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     public static final String ENCODE = "UTF-8";
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/account/impl/DefaultAccountService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/account/impl/DefaultAccountService.java
@@ -23,7 +23,7 @@ import com.autohome.frostmourne.monitor.service.account.IUserInfoService;
 @Service
 public class DefaultAccountService implements IAccountService {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(DefaultAccountService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAccountService.class);
 
     @Resource
     private IUserInfoService userInfoService;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/account/impl/LdapAuthService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/account/impl/LdapAuthService.java
@@ -11,7 +11,7 @@ import com.autohome.frostmourne.monitor.service.account.IAuthService;
 
 public class LdapAuthService implements IAuthService {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(LdapAuthService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapAuthService.class);
 
     private final LdapTemplate ldapTemplate;
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/alert/AlertService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/alert/AlertService.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 @Service
 public class AlertService implements IAlertService {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(AlertService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlertService.class);
 
     @Value("${frostmourne.message.title}")
     private String messageTitle;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/InfluxdbDataQuery.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/InfluxdbDataQuery.java
@@ -17,7 +17,7 @@ import com.autohome.frostmourne.monitor.service.core.query.IInfluxdbDataQuery;
 @Service
 public class InfluxdbDataQuery implements IInfluxdbDataQuery {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(InfluxdbDataQuery.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfluxdbDataQuery.class);
 
     @Resource
     private IInfluxdbDao influxdbDao;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/AbstractRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/AbstractRule.java
@@ -27,7 +27,7 @@ public abstract class AbstractRule implements IRule {
     public final Configuration jsonPathConfiguration =
         Configuration.defaultConfiguration().addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL).addOptions(Option.SUPPRESS_EXCEPTIONS);
 
-    public AbstractRule(ITemplateService templateService) {
+    protected AbstractRule(ITemplateService templateService) {
         this.templateService = templateService;
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JacksonUtils.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JacksonUtils.java
@@ -3,11 +3,10 @@ package com.autohome.frostmourne.monitor.tool;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.autohome.frostmourne.monitor.model.constant.GlobalConstant;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
@@ -63,7 +62,7 @@ public class JacksonUtils {
      */
     public static byte[] toJsonBytes(Object obj) {
         try {
-            return mapper.writeValueAsString(obj).getBytes(Charset.forName(GlobalConstant.ENCODE));
+            return mapper.writeValueAsString(obj).getBytes(StandardCharsets.UTF_8);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(String.format(MSG_FOR_SERIALIZE_CLASS, obj.getClass().getName(), e.getMessage()), e);
         }
@@ -80,7 +79,7 @@ public class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, Class<T> cls) {
         try {
-            return toObj(StringUtils.toEncodedString(json, Charset.forName(GlobalConstant.ENCODE)), cls);
+            return toObj(StringUtils.toEncodedString(json, StandardCharsets.UTF_8), cls);
         } catch (Exception e) {
             throw new RuntimeException(String.format(MSG_FOR_DESERIALIZE_CLASS, cls.getName(), e.getMessage()), e);
         }
@@ -97,7 +96,7 @@ public class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, Type cls) {
         try {
-            return toObj(StringUtils.toEncodedString(json, Charset.forName(GlobalConstant.ENCODE)), cls);
+            return toObj(StringUtils.toEncodedString(json, StandardCharsets.UTF_8), cls);
         } catch (Exception e) {
             throw new RuntimeException(String.format(MSG_FOR_DESERIALIZE_CLASS, cls.getClass().getName(), e.getMessage()), e);
         }
@@ -131,7 +130,7 @@ public class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, TypeReference<T> typeReference) {
         try {
-            return toObj(StringUtils.toEncodedString(json, Charset.forName(GlobalConstant.ENCODE)), typeReference);
+            return toObj(StringUtils.toEncodedString(json, StandardCharsets.UTF_8), typeReference);
         } catch (Exception e) {
             throw new RuntimeException(String.format(MSG_FOR_DESERIALIZE_CLASS, typeReference.getClass().getName(), e.getMessage()), e);
         }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JacksonUtils.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JacksonUtils.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class JacksonUtils {
 
-    private final static String OBJECT_MAPPER_BEAN_ID = "objectMapper";
+    private static final String OBJECT_MAPPER_BEAN_ID = "objectMapper";
 
     private static final String MSG_FOR_SERIALIZE_CLASS = "serialize for class [%s] failed: [%s]";
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JwtToken.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/JwtToken.java
@@ -15,11 +15,11 @@ import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtToken {
-    private final static Long EXPIRE = 1000 * 60 * 60 * 24L;
+    private static final Long EXPIRE = 1000 * 60 * 60 * 24L;
 
-    private final static Key KEY = Keys.hmacShaKeyFor("伏地魔,狗到天荒地老,狗出新高度".getBytes(StandardCharsets.UTF_8));
+    private static final Key KEY = Keys.hmacShaKeyFor("伏地魔,狗到天荒地老,狗出新高度".getBytes(StandardCharsets.UTF_8));
 
-    private final static String SALT = "别杀我，我是鲁班7号";
+    private static final String SALT = "别杀我，我是鲁班7号";
 
     public String generateToken(AccountInfo accountInfo) {
         return Jwts.builder().claim("salt", SALT).claim("userinfo", JacksonUtil.serialize(accountInfo)).setSubject(accountInfo.getAccount())

--- a/frostmourne-monitor/src/main/resources/application-local.properties
+++ b/frostmourne-monitor/src/main/resources/application-local.properties
@@ -34,4 +34,4 @@ your.wechat.corpid=
 your.wechat.agentid=
 your.wechat.secret=
 
-schedule_enabled=false
+schedule_enabled=true

--- a/frostmourne-monitor/src/test/java/com/autohome/frostmourne/monitor/tool/JwtTokenTest.java
+++ b/frostmourne-monitor/src/test/java/com/autohome/frostmourne/monitor/tool/JwtTokenTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 public class JwtTokenTest {
 
-    private final static Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
     @Test
     public void generateTokenTest() {

--- a/frostmourne-vue/src/lang/en.js
+++ b/frostmourne-vue/src/lang/en.js
@@ -5,6 +5,7 @@ export default {
     search: 'search',
     add: 'add',
     run: 'run',
+    onceRun: 'onetime',
     export: 'export',
     edit: 'edit',
     delete: 'delete',
@@ -12,7 +13,8 @@ export default {
     confirm: 'confirm',
     save: 'save',
     test: 'test',
-    save_another: 'save another'
+    save_another: 'save another',
+    view: 'view'
   },
   route: {
     Dashboard: 'Dashboard',

--- a/frostmourne-vue/src/lang/zh.js
+++ b/frostmourne-vue/src/lang/zh.js
@@ -6,6 +6,7 @@ export default {
     search: '查询',
     add: '添加',
     run: '运行',
+    onceRun: '执行一次',
     export: '导出',
     edit: '编辑',
     delete: '删除',
@@ -14,6 +15,7 @@ export default {
     save: '保存',
     test: '测试',
     save_another: '另存',
+    view: '查看'
   },
   route: {
     Dashboard: '首页',

--- a/frostmourne-vue/src/views/alarm/list.vue
+++ b/frostmourne-vue/src/views/alarm/list.vue
@@ -45,7 +45,7 @@
             @show="nextTriggerTime(scope.row)"
           >
             <h5 v-html="triggerNextTimes" />
-            <el-button slot="reference" size="small">查看</el-button>
+            <el-button slot="reference" size="small">{{ $t('buttons.view') }}</el-button>
           </el-popover>
         </template>
       </el-table-column>
@@ -60,7 +60,7 @@
       <el-table-column :label="$t('alarm.list.header_action')" width="300" align="center" fixed="right">
         <template slot-scope="scope">
           <el-button size="mini" icon="el-icon-edit" @click="goEdit(scope.row.id)">{{ $t('buttons.edit') }}</el-button>
-          <el-button size="mini" icon="el-icon-edit" @click="run(scope.row.id)">{{ $t('buttons.run') }}</el-button>
+          <el-button size="mini" icon="el-icon-edit" @click="run(scope.row.id)">{{ $t('buttons.onceRun') }}</el-button>
           <el-button size="mini" icon="el-icon-edit" @click="remove(scope.row.id)">{{ $t('buttons.delete') }}</el-button>
         </template>
       </el-table-column>


### PR DESCRIPTION
1. code style `static final` 修饰符推荐排序，整个项目保持一致。
2. 使用StandardCharsets.UTF_8 替代硬编码
3. web ui button 文案调整，`运行` 改成 `执行一次` 避免语义模糊，同时将 `查看` 配置化、国际化
4. 配置修改默认开启调度