### PR TITLE
启动脚本支持jdk1.8 ~ 14版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://github.com/AutohomeCorp/frostmourne/fork"><img src="https://img.shields.io/github/forks/AutohomeCorp/frostmourne" alt="GitHub Forks"></a>
 <a href="https://github.com/AutohomeCorp/frostmourne/graphs/contributors"><img src="https://img.shields.io/github/contributors/AutohomeCorp/frostmourne" alt="GitHub Contributors"></a>
 <a href="https://github.com/AutohomeCorp/frostmourne/issues"><img src="https://img.shields.io/github/issues/AutohomeCorp/frostmourne" alt="GitHub issues"></a>
-<a href="https://openjdk.java.net/"><img src="https://img.shields.io/badge/Java-8-blue?logo=java&logoColor=white" alt="JDK support"></a>
+<a href="https://openjdk.java.net/"><img src="https://img.shields.io/badge/Java-8,11,13-blue?logo=java&logoColor=white" alt="JDK support"></a>
 <a href="https://github.com/AutohomeCorp/frostmourne/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/svelte.svg" alt="LICENSE"></a>
 <a href="https://github.com/AutohomeCorp/frostmourne"><img src="https://img.shields.io/github/downloads/AutohomeCorp/frostmourne/total.svg" alt="Downloads"></a>
 </p>
@@ -109,7 +109,7 @@ kubectl apply -f frostmourne-monitor-service.yaml
 #### 二、`zip`包部署方式
 
 依赖环境
-* `JDK 1.8`
+* `JDK 1.8 ~ 14`
 * `MySQL 5.7.8+`
 
 最新的Release版本zip包，请到 [releases](https://github.com/AutohomeCorp/frostmourne/releases) 中下载，解压后然后根据自己的环境修改应用配置文件`application.properties`文件和环境变量配置文件`env`，然后执行如下命令启动：
@@ -127,7 +127,7 @@ kubectl apply -f frostmourne-monitor-service.yaml
 #### 三、自构建部署方式
 
 依赖环境
-* `JDK 1.8`
+* `JDK 1.8 ~ 14`
 * `Maven 3.2.x+`
 * `MySQL 5.7.8+`
 
@@ -190,7 +190,7 @@ mvn -U clean package -DskipTests=true
 
 调试环境要求
 
-* `JDK 1.8`
+* `JDK 1.8 ~ 14`
 * `Node 16.14.2 (推荐)`
 * `Yarn 1.22.10 (推荐) 或 Npm 8.7.0`
 * `MySQL 5.7.8+`


### PR DESCRIPTION
变更点：

1. 启动脚本支持jdk 1.8 ~ 14
2. 更新readme 支持1.8~14版本

---

在jdk 1.8, 11, 13 测试启动脚本均通过，如下

jdk 1.8

```sh
/usr/bin/java
jdk version: 1.8.0_333
2022年 8月 4日 星期四 18时01分25秒 CST ==== Starting ==== 
Started [38916]
Waiting for server startup..
2022年 8月 4日 星期四 18时01分36秒 CST Server started in 10 seconds!
```
jdk 11

```sh
jdk version: 11.0.13
2022年 8月 4日 星期四 17时39分00秒 CST ==== Starting ==== 
Started [28654]
Waiting for server startup...
2022年 8月 4日 星期四 17时39分17秒 CST Server started in 15 seconds!
```

jdk 13

```sh
/usr/bin/java
jdk version: 13
2022年 8月 4日 星期四 17时30分39秒 CST ==== Starting ====
Started [95773]
Waiting for server startup..
2022年 8月 4日 星期四 17时30分51秒 CST Server started in 10 seconds!
```
