### PR TITLE
set druid connect retry time-interval.

### DIFF
--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/DataSourceJdbcManager.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/DataSourceJdbcManager.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.dao.jdbc.impl;
 
 import java.sql.SQLException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -110,6 +111,7 @@ public class DataSourceJdbcManager implements IDataSourceJdbcManager {
         dataSource.setTestOnBorrow(true);
         dataSource.setTestOnReturn(true);
         dataSource.setValidationQuery("SELECT 1");
+        dataSource.setTimeBetweenConnectErrorMillis(TimeUnit.SECONDS.toMillis(10L));
         // 密码默认是明文
         dataSource.getConnectProperties().setProperty("config.decrypt", "false");
         // 初始化连接


### PR DESCRIPTION
fix #106 
设置10s重试连接，避免日志刷屏。

```sh
2022-08-15 15:24:28.051 ERROR 80258 --- [eate-1008665686] c.a.d.p.DruidDataSource                  : create connection SQLException, url: 192.168.3.234, errorCode 0, state null

java.sql.SQLException: connect error, url 192.168.3.234, driverClass com.mysql.cj.jdbc.Driver
	at com.alibaba.druid.pool.DruidAbstractDataSource.createPhysicalConnection(DruidAbstractDataSource.java:1714) ~[druid-1.1.22.jar:1.1.22]
	at com.alibaba.druid.pool.DruidDataSource$CreateConnectionThread.run(DruidDataSource.java:2779) [druid-1.1.22.jar:1.1.22]

2022-08-15 15:24:38.056 ERROR 80258 --- [eate-1008665686] c.a.d.p.DruidDataSource                  : create connection SQLException, url: 192.168.3.234, errorCode 0, state null

java.sql.SQLException: connect error, url 192.168.3.234, driverClass com.mysql.cj.jdbc.Driver
	at com.alibaba.druid.pool.DruidAbstractDataSource.createPhysicalConnection(DruidAbstractDataSource.java:1714) ~[druid-1.1.22.jar:1.1.22]
	at com.alibaba.druid.pool.DruidDataSource$CreateConnectionThread.run(DruidDataSource.java:2779) [druid-1.1.22.jar:1.1.22]

2022-08-15 15:24:48.062 ERROR 80258 --- [eate-1008665686] c.a.d.p.DruidDataSource                  : create connection SQLException, url: 192.168.3.234, errorCode 0, state null

java.sql.SQLException: connect error, url 192.168.3.234, driverClass com.mysql.cj.jdbc.Driver
	at com.alibaba.druid.pool.DruidAbstractDataSource.createPhysicalConnection(DruidAbstractDataSource.java:1714) ~[druid-1.1.22.jar:1.1.22]
```