### PR TITLE
对于查询异常进行抛出

### DIFF
--- a/frostmourne-common/src/main/java/com/autohome/frostmourne/common/exception/DataQueryException.java
+++ b/frostmourne-common/src/main/java/com/autohome/frostmourne/common/exception/DataQueryException.java
@@ -1,0 +1,30 @@
+package com.autohome.frostmourne.common.exception;
+
+/**
+ * Data query exception.
+ *
+ * @author limbo
+ * @since 2022/8/18 11:30
+ */
+public class DataQueryException extends Exception {
+
+    public DataQueryException() {
+        super();
+    }
+
+    public DataQueryException(String message) {
+        super(message);
+    }
+
+    public DataQueryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataQueryException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DataQueryException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/frostmourne-monitor/pom.xml
+++ b/frostmourne-monitor/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.rest.version}</version>

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/AlarmController.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/AlarmController.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import com.autohome.frostmourne.monitor.schedule.CronExpression;
 import com.autohome.frostmourne.monitor.tool.LocalDateTimeUtils;
@@ -60,7 +61,13 @@ public class AlarmController {
             dataSourceType = DataSourceType.valueOf(alarmContract.getMetricContract().getDataName());
         }
         IMetric metric = this.metricService.findMetric(dataSourceType, alarmContract.getMetricContract().getMetricType());
-        Map<String, Object> result = metric.pullMetric(alarmContract.getMetricContract(), alarmContract.getRuleContract().getSettings());
+        Map<String, Object> result = null;
+        try {
+            result = metric.pullMetric(alarmContract.getMetricContract(), alarmContract.getRuleContract().getSettings());
+        } catch (DataQueryException e) {
+            return Protocol.fail(e.getMessage());
+        }
+
         if (alarmContract.getRuleContract().getSettings() != null) {
             result.putAll(alarmContract.getRuleContract().getSettings());
         }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/IJdbcDao.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/IJdbcDao.java
@@ -3,11 +3,15 @@ package com.autohome.frostmourne.monitor.dao.jdbc;
 import java.util.List;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.DataNameContract;
 import com.autohome.frostmourne.monitor.model.contract.DataSourceContract;
 
 public interface IJdbcDao {
 
-    List<Map<String, Object>> query(DataNameContract dataNameContract, DataSourceContract dataSourceContract, String sql, Object[] args);
+    List<Map<String, Object>> query(DataNameContract dataNameContract,
+                                    DataSourceContract dataSourceContract,
+                                    String sql,
+                                    Object[] args) throws DataQueryException;
 
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/JdbcDao.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/JdbcDao.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import javax.sql.DataSource;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,8 @@ public class JdbcDao implements IJdbcDao {
     private IDataSourceJdbcManager dataSourceJdbcManager;
 
     @Override
-    public List<Map<String, Object>> query(DataNameContract dataNameContract, DataSourceContract dataSourceContract, String sql, Object[] args) {
+    public List<Map<String, Object>> query(DataNameContract dataNameContract, DataSourceContract dataSourceContract, String sql, Object[] args)
+            throws DataQueryException {
         try {
             DataSource dataSource = dataSourceJdbcManager.getDataSource(dataSourceContract);
             if (dataSource == null) {
@@ -34,7 +36,7 @@ public class JdbcDao implements IJdbcDao {
             return this.query(dataSource, sql, args);
         } catch (Exception e) {
             log.error("JdbcDataQuery.query error: dataSource={}, sql={}, {}", dataSourceContract, sql, e.getMessage(), e);
-            return Collections.emptyList();
+            throw new DataQueryException(e);
         }
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/constant/ContextConstant.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/constant/ContextConstant.java
@@ -8,12 +8,22 @@ package com.autohome.frostmourne.monitor.model.constant;
  */
 public class ContextConstant {
 
-    public final static String ALERT_SILENCE = "ALERT_SILENCE";
+    public static final String ALERT_SILENCE = "ALERT_SILENCE";
 
-    public final static String CURRENT_TIME = "CURRENT_TIME";
+    public static final String CURRENT_TIME = "CURRENT_TIME";
 
-    public final static String ALARM_ID = "ALARM_ID";
+    public static final String ALARM_ID = "ALARM_ID";
 
-    public final static String ALARM_NAME = "ALARM_NAME";
+    public static final String ALARM_NAME = "ALARM_NAME";
+
+    /**
+     * 度量执行状态字段
+     */
+    public static final String METRIC_EXEC_STATUS_FIELD = "EXEC_STATUS";
+
+    /**
+     * 度量执行异常字段
+     */
+    public static final String METRIC_EXEC_ERR_FIELD = "EXEC_ERR";
 
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/AbstractNumericMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/AbstractNumericMetric.java
@@ -3,6 +3,7 @@ package com.autohome.frostmourne.monitor.service.core.metric;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.MetricEnumType;
 import org.joda.time.DateTime;
 
@@ -11,7 +12,7 @@ import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
 
 public abstract class AbstractNumericMetric extends AbstractBaseMetric {
 
-    public abstract MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings);
+    public abstract MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException;
 
     public Integer findTimeWindowInMinutes(Map<String, String> ruleSettings) {
         if (!ruleSettings.containsKey("TIME_WINDOW")) {
@@ -21,7 +22,7 @@ public abstract class AbstractNumericMetric extends AbstractBaseMetric {
     }
 
     @Override
-    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) {
+    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         DateTime end = DateTime.now();
         DateTime start = null;
         Integer minutes = findTimeWindowInMinutes(ruleSettings);

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/AbstractSameTimeMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/AbstractSameTimeMetric.java
@@ -1,16 +1,14 @@
 package com.autohome.frostmourne.monitor.service.core.metric;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.MetricEnumType;
 import com.autohome.frostmourne.monitor.tool.MathUtils;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
@@ -19,9 +17,7 @@ import com.google.common.base.Splitter;
 
 public abstract class AbstractSameTimeMetric extends AbstractBaseMetric {
 
-    public abstract MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings);
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSameTimeMetric.class);
+    public abstract MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException;
 
     /**
      * 获取间隔单位；HOUR: 小时；DAY: 天
@@ -99,7 +95,7 @@ public abstract class AbstractSameTimeMetric extends AbstractBaseMetric {
     }
 
     @Override
-    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) {
+    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         Map<String, Object> resultMap = new HashMap<>();
         String periodUnit = findPeriodUnit(ruleSettings);
         DateTime now = DateTime.now();
@@ -121,7 +117,7 @@ public abstract class AbstractSameTimeMetric extends AbstractBaseMetric {
                 referenceDataList.add(referenceBag);
             }
             resultMap.put("REFERENCE_LIST", referenceDataList);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new RuntimeException("error when calculateReference", ex);
         }
 
@@ -134,7 +130,7 @@ public abstract class AbstractSameTimeMetric extends AbstractBaseMetric {
     }
 
     private ReferenceBag calculateReference(DateTime start, DateTime end, String referenceType, MetricContract metricContract, Double current,
-                                            Map<String, String> ruleSettings) throws IOException {
+        Map<String, String> ruleSettings) throws DataQueryException {
         ReferenceBag referenceBag = new ReferenceBag();
         referenceBag.setReferenceType(referenceType);
         DateTime referenceStart;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/IMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/IMetric.java
@@ -2,12 +2,13 @@ package com.autohome.frostmourne.monitor.service.core.metric;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.model.enums.MetricEnumType;
 
 public interface IMetric {
 
-    Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings);
+    Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException;
 
     MetricEnumType metricType();
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseNumericMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseNumericMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class ClickhouseNumericMetric extends AbstractNumericMetric {
     private IClickhouseDataQuery dataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return dataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseObjectMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseObjectMetric.java
@@ -3,11 +3,11 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
 import com.autohome.frostmourne.monitor.service.core.metric.AbstractObjectMetric;
-import com.autohome.frostmourne.monitor.service.core.metric.IMetric;
 import com.autohome.frostmourne.monitor.service.core.query.IClickhouseDataQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,7 +25,7 @@ public class ClickhouseObjectMetric extends AbstractObjectMetric {
     private IClickhouseDataQuery dataQuery;
 
     @Override
-    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) {
+    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         Map<String, Object> result = new HashMap<>();
         MetricData metricData = dataQuery.querySql(metricContract);
         result.put("NUMBER", metricData.getMetricValue());

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseSameTimeMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/ClickhouseSameTimeMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class ClickhouseSameTimeMetric extends AbstractSameTimeMetric {
     private IClickhouseDataQuery dataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return dataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlNumericMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlNumericMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class MysqlNumericMetric extends AbstractNumericMetric {
     protected IMysqlDataQuery mysqlDataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return mysqlDataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlObjectMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlObjectMetric.java
@@ -3,6 +3,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import com.autohome.frostmourne.monitor.service.core.metric.AbstractObjectMetric;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,7 @@ public class MysqlObjectMetric extends AbstractObjectMetric {
     protected IMysqlDataQuery mysqlDataQuery;
 
     @Override
-    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) {
+    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         Map<String, Object> result = new HashMap<>();
         MetricData metricData = mysqlDataQuery.querySql(metricContract);
         result.put("NUMBER", metricData.getMetricValue());

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlSameTimeMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/MysqlSameTimeMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class MysqlSameTimeMetric extends AbstractSameTimeMetric {
     protected IMysqlDataQuery mysqlDataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return mysqlDataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerNumericMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerNumericMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.service.core.query.impl.SqlServerDataQuery;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class SqlServerNumericMetric extends AbstractNumericMetric {
     protected SqlServerDataQuery sqlServerDataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return sqlServerDataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerObjectMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerObjectMetric.java
@@ -3,6 +3,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.service.core.query.ISqlServerDataQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,7 @@ public class SqlServerObjectMetric extends AbstractObjectMetric {
     protected ISqlServerDataQuery sqlServerDataQuery;
 
     @Override
-    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) {
+    public Map<String, Object> pullMetric(MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         Map<String, Object> result = new HashMap<>();
         MetricData metricData = sqlServerDataQuery.querySql(metricContract);
         result.put("NUMBER", metricData.getMetricValue());

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerSameTimeMetric.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/metric/jdbc/SqlServerSameTimeMetric.java
@@ -2,6 +2,7 @@ package com.autohome.frostmourne.monitor.service.core.metric.jdbc;
 
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
@@ -18,7 +19,7 @@ public class SqlServerSameTimeMetric extends AbstractSameTimeMetric {
     private ISqlServerDataQuery sqlServerDataQuery;
 
     @Override
-    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) {
+    public MetricData pullMetricData(DateTime start, DateTime end, MetricContract metricContract, Map<String, String> ruleSettings) throws DataQueryException {
         return sqlServerDataQuery.queryMetricValue(start, end, metricContract);
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/IMysqlDataQuery.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/IMysqlDataQuery.java
@@ -1,13 +1,15 @@
 package com.autohome.frostmourne.monitor.service.core.query;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
 import org.joda.time.DateTime;
 
+
 public interface IMysqlDataQuery {
 
-    MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract);
+    MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) throws DataQueryException;
 
-    MetricData querySql(MetricContract metricContract);
+    MetricData querySql(MetricContract metricContract) throws DataQueryException;
 
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/ISqlServerDataQuery.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/ISqlServerDataQuery.java
@@ -1,12 +1,13 @@
 package com.autohome.frostmourne.monitor.service.core.query;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
 import org.joda.time.DateTime;
 
 public interface ISqlServerDataQuery {
 
-    MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract);
+    MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) throws DataQueryException;
 
-    MetricData querySql(MetricContract metricContract);
+    MetricData querySql(MetricContract metricContract) throws DataQueryException;
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/MysqlDataQuery.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/MysqlDataQuery.java
@@ -1,9 +1,11 @@
 package com.autohome.frostmourne.monitor.service.core.query.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,7 +23,7 @@ public class MysqlDataQuery implements IMysqlDataQuery {
     protected IJdbcDao jdbcDao;
 
     @Override
-    public MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) {
+    public MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) throws DataQueryException {
         String timeField = metricContract.getDataNameContract().getTimestampField();
         if (StringUtils.isEmpty(metricContract.getDataNameContract().getTimestampField())) {
             throw new RuntimeException("数据名时间字段不能为空: " + metricContract.getDataNameContract().getDataName());
@@ -57,14 +59,14 @@ public class MysqlDataQuery implements IMysqlDataQuery {
     }
 
     @Override
-    public MetricData querySql(MetricContract metricContract) {
+    public MetricData querySql(MetricContract metricContract) throws DataQueryException {
         MetricData result = new MetricData();
         long count = collectResult(metricContract, metricContract.getQueryString(), null);
         result.setMetricValue(count);
         String querySql = "select * from ("+ metricContract.getQueryString() + ") t limit 50";
         List<Map<String, Object>> collectResult = jdbcDao.query(metricContract.getDataNameContract(),
                 metricContract.getDataSourceContract(), querySql, null);
-        if(collectResult != null && collectResult.size() > 0) {
+        if (collectResult != null && !collectResult.isEmpty()) {
             Map<String, Object> lastDocument = collectResult.get(0);
             result.setLatestDocument(lastDocument);
             result.setTopNDocuments(collectResult);
@@ -82,22 +84,23 @@ public class MysqlDataQuery implements IMysqlDataQuery {
         return date.toDate();
     }
 
-    protected long collectResult(MetricContract metricContract, String sql, Object[] args) {
+    protected long collectResult(MetricContract metricContract, String sql, Object[] args) throws DataQueryException {
         String collectSql = "select count(*) cnt from (" + sql + ") t";
-        List<Map<String, Object>> collectResult = jdbcDao.query(metricContract.getDataNameContract(), metricContract.getDataSourceContract(), collectSql, args);
-        if (collectResult != null && collectResult.size() > 0) {
+        List<Map<String, Object>> collectResult =
+                jdbcDao.query(metricContract.getDataNameContract(), metricContract.getDataSourceContract(), collectSql, args);
+        if (collectResult != null && !collectResult.isEmpty()) {
             return ((Number)collectResult.get(0).get("cnt")).longValue();
         }
         return 0L;
     }
 
-    protected Map<String, Object> queryLatestDocument(MetricContract metricContract, String sql, Object[] args) {
+    protected Map<String, Object> queryLatestDocument(MetricContract metricContract, String sql, Object[] args) throws DataQueryException {
         String querySql = sql + " order by " + metricContract.getDataNameContract().getTimestampField() + " desc limit 1";
         List<Map<String, Object>> collectResult = jdbcDao.query(metricContract.getDataNameContract(), metricContract.getDataSourceContract(), querySql, args);
-        if (collectResult != null && collectResult.size() > 0) {
+        if (collectResult != null && !collectResult.isEmpty()) {
             return collectResult.get(0);
         }
-        return null;
+        return Collections.emptyMap();
     }
 
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/SqlServerDataQuery.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/query/impl/SqlServerDataQuery.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.autohome.frostmourne.common.exception.DataQueryException;
 import com.autohome.frostmourne.monitor.dao.jdbc.IJdbcDao;
 import com.autohome.frostmourne.monitor.model.contract.MetricContract;
 import com.autohome.frostmourne.monitor.service.core.domain.MetricData;
@@ -20,7 +21,7 @@ public class SqlServerDataQuery implements ISqlServerDataQuery {
     protected IJdbcDao jdbcDao;
 
     @Override
-    public MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) {
+    public MetricData queryMetricValue(DateTime start, DateTime end, MetricContract metricContract) throws DataQueryException {
         String timeField = metricContract.getDataNameContract().getTimestampField();
         if (StringUtils.isEmpty(metricContract.getDataNameContract().getTimestampField())) {
             throw new RuntimeException("数据名时间字段不能为空: " + metricContract.getDataNameContract().getDataName());
@@ -56,7 +57,7 @@ public class SqlServerDataQuery implements ISqlServerDataQuery {
     }
 
     @Override
-    public MetricData querySql(MetricContract metricContract) {
+    public MetricData querySql(MetricContract metricContract) throws DataQueryException {
         MetricData result = new MetricData();
         long count = collectResult(metricContract, metricContract.getQueryString(), null);
         result.setMetricValue(count);
@@ -81,7 +82,7 @@ public class SqlServerDataQuery implements ISqlServerDataQuery {
         return date.toDate();
     }
 
-    protected long collectResult(MetricContract metricContract, String sql, Object[] args) {
+    protected long collectResult(MetricContract metricContract, String sql, Object[] args) throws DataQueryException {
         String collectSql = "select count(*) cnt from (" + sql + ") t";
         List<Map<String, Object>> collectResult = jdbcDao.query(metricContract.getDataNameContract(), metricContract.getDataSourceContract(), collectSql, args);
         if (collectResult != null && collectResult.size() > 0) {
@@ -90,7 +91,7 @@ public class SqlServerDataQuery implements ISqlServerDataQuery {
         return 0L;
     }
 
-    protected Map<String, Object> queryLatestDocument(MetricContract metricContract, String sql, Object[] args) {
+    protected Map<String, Object> queryLatestDocument(MetricContract metricContract, String sql, Object[] args) throws DataQueryException {
         String querySql = "select top 1 * from (" + sql + ") as t order by " + metricContract.getDataNameContract().getTimestampField() + " desc;";
         List<Map<String, Object>> collectResult = jdbcDao.query(metricContract.getDataNameContract(), metricContract.getDataSourceContract(), querySql, args);
         if (collectResult != null && collectResult.size() > 0) {

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/BucketNumbericRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/BucketNumbericRule.java
@@ -27,6 +27,8 @@ public class BucketNumbericRule extends AbstractRule {
     @Override
     public boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric) {
         Map<String, Object> context = context(alarmProcessLogger, ruleContract, metricContract, metric);
+        checkMetricRunState(context);
+        
         List<BucketInfo> buckets = findBuckets(context);
         List<BucketInfo> verifiedBuckets = new ArrayList<>();
         Double threshold = findThreshold(ruleContract);

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/ExpressionRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/ExpressionRule.java
@@ -30,6 +30,7 @@ public class ExpressionRule extends AbstractRule {
     @Override
     public boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric) {
         Map<String, Object> context = context(alarmProcessLogger, ruleContract, metricContract, metric);
+        checkMetricRunState(context);
 
         SimpleBindings simpleBindings = new SimpleBindings();
         simpleBindings.putAll(context);

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/IRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/IRule.java
@@ -12,4 +12,18 @@ public interface IRule {
     boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric);
 
     String alertMessage(String alertTemplate, Map<String, Object> context);
+
+    /**
+     * 检查指标运行状态
+     *
+     * 如果执行异常则上下文包含异常字段，抛出异常
+     *
+     * @param context 上下文
+     */
+    default void checkMetricRunState(Map<String, Object> context) {
+        if (context.containsKey("EXEC_STATUS") && context.containsKey("EXEC_ERR")) {
+            throw new RuntimeException("EXEC_STATUS=" + context.get("EXEC_STATUS").toString()
+                    + " | EXEC_ERR=" + context.get("EXEC_ERR").toString());
+        }
+    }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/NumericRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/NumericRule.java
@@ -17,6 +17,8 @@ public class NumericRule extends AbstractRule {
     @Override
     public boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric) {
         Map<String, Object> context = context(alarmProcessLogger, ruleContract, metricContract, metric);
+        checkMetricRunState(context);
+
         Double threshold = findThreshold(ruleContract);
         Double number = findNumber(context);
         String operator = findOperation(ruleContract);

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/PercentageRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/PercentageRule.java
@@ -20,6 +20,8 @@ public class PercentageRule extends AbstractRule {
     @Override
     public boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric) {
         Map<String, Object> context = context(alarmProcessLogger, ruleContract, metricContract, metric);
+        checkMetricRunState(context);
+
         Map<String, String> ruleSettings = ruleContract.getSettings();
         List<ReferenceBag> referenceDataList = findReference(context);
         boolean verifyResult = true;

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/PingRule.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/core/rule/PingRule.java
@@ -17,6 +17,8 @@ public class PingRule extends AbstractRule {
     @Override
     public boolean verify(AlarmProcessLogger alarmProcessLogger, RuleContract ruleContract, MetricContract metricContract, IMetric metric) {
         Map<String, Object> context = context(alarmProcessLogger, ruleContract, metricContract, metric);
+        checkMetricRunState(context);
+
         Integer failCount = (Integer)context.get("FAIL_COUNT");
         return failCount > 0;
     }


### PR DESCRIPTION
变更点 #108 

目前方式：如果语法错误或数据库等中途报错，对于前端会抛出异常，对于定时任务会标记执行结果异常并标记异常原因。

效果如下：

<img width="1215" alt="企业微信截图_bf9cdd14-b8eb-45c3-ac15-e4631380eaeb" src="https://user-images.githubusercontent.com/4414032/185343587-7ec35d53-cfe6-4108-b7a8-f3b0bc0a2a4a.png">
<img width="1518" alt="企业微信截图_fc19a50b-9a07-4613-8b81-39345dad5ccb" src="https://user-images.githubusercontent.com/4414032/185343612-8c7ef52b-7215-4ca6-bb10-ddefad0bc55c.png">
<img width="1046" alt="企业微信截图_724a2fb2-d5cb-4443-911f-5566ac8fd51c" src="https://user-images.githubusercontent.com/4414032/185343633-0fcaad73-dece-4607-9afd-76701a4c2172.png">
