### PR TITLE
Encrypt sensitive information.

### DIFF
--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/config/properties/EncryptProperties.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/config/properties/EncryptProperties.java
@@ -1,0 +1,59 @@
+package com.autohome.frostmourne.monitor.config.properties;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * 加密配置类
+ *
+ * @author limbo
+ * @since 2022/9/14 13:48
+ */
+@Configuration
+public class EncryptProperties implements InitializingBean {
+
+    private static EncryptProperties prop = null;
+
+    public static EncryptProperties getInstance () {
+        return prop;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        prop = this;
+    }
+
+    /**
+     * 密钥
+     */
+    @Value("${encrypt.key:EX31$@*^ac1}")
+    private String key;
+
+    /**
+     * 敏感字段列表
+     *
+     * 默认会对 data_source表 properties字段值进行加密
+     * 对于username, password等配置等敏感字段也要进行加解密操作，避免在前端泄漏
+     */
+    @Value("#{'${encrypt.sensitives:username,password}'.split(',')}")
+    private List<String> sensitiveFields;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public List<String> getSensitiveFields() {
+        return sensitiveFields;
+    }
+
+    public void setSensitiveFields(List<String> sensitiveFields) {
+        this.sensitiveFields = sensitiveFields;
+    }
+}

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/AdminController.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/controller/AdminController.java
@@ -4,6 +4,7 @@ import javax.annotation.Resource;
 
 import com.autohome.frostmourne.monitor.dao.mybatis.frostmourne.domain.generate.Alarm;
 import com.autohome.frostmourne.monitor.model.enums.AlarmStatus;
+import com.autohome.frostmourne.monitor.tool.AESUtils;
 import org.springframework.web.bind.annotation.*;
 
 import com.autohome.frostmourne.common.contract.PagerContract;
@@ -11,6 +12,9 @@ import com.autohome.frostmourne.common.contract.Protocol;
 import com.autohome.frostmourne.monitor.model.contract.AlarmContract;
 import com.autohome.frostmourne.monitor.service.admin.IAlarmAdminService;
 import com.autohome.frostmourne.monitor.tool.AuthTool;
+
+import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequestMapping(value = {"/admin", "/api/monitor-api/admin"})
@@ -58,6 +62,13 @@ public class AdminController {
         if (alarmContract == null) {
             return new Protocol<>(404, "监控不存在");
         }
+
+        // 敏感信息加密
+        Map<String, String> settings = alarmContract.getMetricContract().getDataSourceContract().getSettings();
+        if (Objects.nonNull(settings)) {
+            AESUtils.encryptMappingSensitive(settings);
+            alarmContract.getMetricContract().getDataSourceContract().setSettings(settings);
+        }
         return new Protocol<>(alarmContract);
     }
 
@@ -66,4 +77,5 @@ public class AdminController {
         PagerContract<Alarm> pagerContract = this.alarmAdminService.find(pageIndex, pageSize, alarmId, name, teamName, status, serviceId);
         return new Protocol<>(pagerContract);
     }
+
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/DataSourceJdbcType.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/DataSourceJdbcType.java
@@ -1,5 +1,7 @@
 package com.autohome.frostmourne.monitor.dao.jdbc;
 
+import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
+
 public enum DataSourceJdbcType {
 
     /**
@@ -30,6 +32,10 @@ public enum DataSourceJdbcType {
 
     public String getDriverClassName() {
         return driverClassName;
+    }
+
+    public static DataSourceJdbcType fromDataSourceType(DataSourceType dataSourceType) {
+        return DataSourceJdbcType.valueOf(dataSourceType.name().toUpperCase());
     }
 
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/DataSourceJdbcManager.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/jdbc/impl/DataSourceJdbcManager.java
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
-import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,13 +96,7 @@ public class DataSourceJdbcManager implements IDataSourceJdbcManager {
 
     private DruidDataSource createDataSource(DataSourceContract dataSourceContract) throws SQLException {
         DruidDataSource dataSource = new DruidDataSource();
-        if (DataSourceType.clickhouse.equals(dataSourceContract.getDatasourceType())) {
-            dataSource.setDriverClassName(DataSourceJdbcType.CLICKHOUSE.getDriverClassName());
-        } else if (DataSourceType.mysql.equals(dataSourceContract.getDatasourceType())) {
-            dataSource.setDriverClassName(DataSourceJdbcType.MYSQL.getDriverClassName());
-        } else if (DataSourceType.sqlserver.equals(dataSourceContract.getDatasourceType())) {
-            dataSource.setDriverClassName(DataSourceJdbcType.SQLSERVER.getDriverClassName());
-        }
+        dataSource.setDriverClassName(DataSourceJdbcType.fromDataSourceType(dataSourceContract.getDatasourceType()).getDriverClassName());
         dataSource.setUrl(dataSourceContract.getServiceAddress());
         dataSource.setUsername(dataSourceContract.getSettings().get("username"));
         dataSource.setPassword(dataSourceContract.getSettings().get("password"));

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/domain/generate/DataSource.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/domain/generate/DataSource.java
@@ -167,4 +167,19 @@ public class DataSource implements Serializable {
         result = prime * result + ((getProperties() == null) ? 0 : getProperties().hashCode());
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "DataSource{" +
+                "id=" + id +
+                ", datasourceName='" + datasourceName + '\'' +
+                ", datasourceType=" + datasourceType +
+                ", serviceAddress='" + serviceAddress + '\'' +
+                ", creator='" + creator + '\'' +
+                ", createAt=" + createAt +
+                ", modifier='" + modifier + '\'' +
+                ", modifyAt=" + modifyAt +
+                ", properties='" + properties + '\'' +
+                '}';
+    }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/mapper/dynamic/DataSourceDynamicMapper.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/mapper/dynamic/DataSourceDynamicMapper.java
@@ -6,6 +6,8 @@ import static org.mybatis.dynamic.sql.SqlBuilder.*;
 import com.autohome.frostmourne.monitor.dao.mybatis.frostmourne.domain.generate.DataSource;
 import java.util.List;
 import java.util.Optional;
+
+import com.autohome.frostmourne.monitor.handler.CryptoTypeHandler;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Mapper;
@@ -58,7 +60,7 @@ public interface DataSourceDynamicMapper {
         @Result(column="create_at", property="createAt", jdbcType=JdbcType.TIMESTAMP),
         @Result(column="modifier", property="modifier", jdbcType=JdbcType.VARCHAR),
         @Result(column="modify_at", property="modifyAt", jdbcType=JdbcType.TIMESTAMP),
-        @Result(column="properties", property="properties", jdbcType=JdbcType.LONGVARCHAR)
+        @Result(column="properties", property="properties", jdbcType=JdbcType.LONGVARCHAR, typeHandler = CryptoTypeHandler.class)
     })
     List<DataSource> selectMany(SelectStatementProvider selectStatement);
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/mapper/dynamic/DataSourceDynamicSqlSupport.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/dao/mybatis/frostmourne/mapper/dynamic/DataSourceDynamicSqlSupport.java
@@ -71,7 +71,7 @@ public final class DataSourceDynamicSqlSupport {
 
         public final SqlColumn<Date> modifyAt = column("modify_at", JDBCType.TIMESTAMP);
 
-        public final SqlColumn<String> properties = column("properties", JDBCType.LONGVARCHAR);
+        public final SqlColumn<String> properties = column("properties", JDBCType.LONGVARCHAR, "com.autohome.frostmourne.monitor.handler.CryptoTypeHandler");
 
         public DataSource() {
             super("data_source");

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/handler/CryptoTypeHandler.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/handler/CryptoTypeHandler.java
@@ -1,0 +1,58 @@
+package com.autohome.frostmourne.monitor.handler;
+
+import com.autohome.frostmourne.monitor.tool.AESUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.*;
+import java.util.Objects;
+
+/**
+ * 加解密mybatis TypeHandler
+ *
+ * @author limbo
+ * @since 2022/9/9 15:08
+ */
+@MappedTypes({String.class})
+public class CryptoTypeHandler implements TypeHandler<String> {
+
+    /**
+     * 设置加密
+     */
+    @Override
+    public void setParameter(PreparedStatement preparedStatement, int i, String parameter, JdbcType jdbcType) throws SQLException {
+        if (StringUtils.isNotBlank(parameter)) {
+            preparedStatement.setString(i, AESUtils.encrypt(parameter));
+        } else {
+            preparedStatement.setNull(i, Types.VARCHAR);
+        }
+    }
+
+    /**
+     * 设置解密
+     */
+    @Override
+    public String getResult(ResultSet resultSet, String columnName) throws SQLException {
+        return decrypt(resultSet.getString(columnName));
+    }
+
+    @Override
+    public String getResult(ResultSet resultSet, int columnIndex) throws SQLException {
+        return decrypt(resultSet.getString(columnIndex));
+    }
+
+    @Override
+    public String getResult(CallableStatement callableStatement, int columnIndex) throws SQLException {
+        return decrypt(callableStatement.getString(columnIndex));
+    }
+
+    private String decrypt(String result) {
+        if (StringUtils.isNotBlank(result)) {
+            String decrypt = AESUtils.decrypt(result);
+            return Objects.nonNull(decrypt) ? decrypt : result;
+        }
+        return result;
+    }
+}

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataOption.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataOption.java
@@ -1,26 +1,13 @@
 package com.autohome.frostmourne.monitor.model.contract;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class DataOption {
 
     private String datasourceType;
 
     private List<DataSourceOption> dataSourceOptionList;
-
-    public String getDatasourceType() {
-        return datasourceType;
-    }
-
-    public void setDatasourceType(String datasourceType) {
-        this.datasourceType = datasourceType;
-    }
-
-    public List<DataSourceOption> getDataSourceOptionList() {
-        return dataSourceOptionList;
-    }
-
-    public void setDataSourceOptionList(List<DataSourceOption> dataSourceOptionList) {
-        this.dataSourceOptionList = dataSourceOptionList;
-    }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataSourceContract.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataSourceContract.java
@@ -96,4 +96,19 @@ public class DataSourceContract {
     public void setModifyAt(Date modifyAt) {
         this.modifyAt = modifyAt;
     }
+
+    @Override
+    public String toString() {
+        return "DataSourceContract{" +
+                "id=" + id +
+                ", datasourceName='" + datasourceName + '\'' +
+                ", datasourceType=" + datasourceType +
+                ", serviceAddress='" + serviceAddress + '\'' +
+                ", settings=" + settings +
+                ", creator='" + creator + '\'' +
+                ", createAt=" + createAt +
+                ", modifier='" + modifier + '\'' +
+                ", modifyAt=" + modifyAt +
+                '}';
+    }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataSourceOption.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/contract/DataSourceOption.java
@@ -3,26 +3,14 @@ package com.autohome.frostmourne.monitor.model.contract;
 import java.util.List;
 
 import com.autohome.frostmourne.monitor.dao.mybatis.frostmourne.domain.generate.DataSource;
+import com.autohome.frostmourne.monitor.model.vo.DataSourceVO;
+import lombok.Data;
 
+@Data
 public class DataSourceOption {
 
-    private DataSource dataSource;
+    private DataSourceVO dataSourceVO;
 
     private List<DataNameContract> dataNameContractList;
 
-    public DataSource getDataSource() {
-        return dataSource;
-    }
-
-    public void setDataSource(DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
-
-    public List<DataNameContract> getDataNameContractList() {
-        return dataNameContractList;
-    }
-
-    public void setDataNameContractList(List<DataNameContract> dataNameContractList) {
-        this.dataNameContractList = dataNameContractList;
-    }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/vo/DataSourceVO.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/vo/DataSourceVO.java
@@ -7,7 +7,7 @@ import lombok.Data;
 /**
  * description
  *
- * @author fangpeng
+ * @author limbo
  * @since 2022/9/14 18:55
  */
 @Data

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/vo/DataSourceVO.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/model/vo/DataSourceVO.java
@@ -1,0 +1,32 @@
+package com.autohome.frostmourne.monitor.model.vo;
+
+import com.autohome.frostmourne.monitor.model.enums.DataSourceType;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * description
+ *
+ * @author fangpeng
+ * @since 2022/9/14 18:55
+ */
+@Data
+@Builder
+public class DataSourceVO {
+
+    /**
+     * 主键
+     */
+    private Long id;
+
+    /**
+     * 数据源名称
+     */
+    private String datasourceName;
+
+    /**
+     * 数据源类型。(Elasticsearch, Influxdb)
+     */
+    private DataSourceType datasourceType;
+
+}

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/AlarmAdminService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/AlarmAdminService.java
@@ -467,25 +467,19 @@ public class AlarmAdminService implements IAlarmAdminService {
 
     @Override
     public void padAlarm(AlarmContract alarmContract) {
-        alarmContract.setAlarmType(alarmContract.getMetricContract().getDataName());
+        String dataNameStr = alarmContract.getMetricContract().getDataName();
+        alarmContract.setAlarmType(dataNameStr);
         String ruleType = metricRuleMap.get(alarmContract.getMetricContract().getMetricType());
         alarmContract.getRuleContract().setRuleType(ruleType);
-        if (alarmContract.getMetricContract().getDataName().equalsIgnoreCase("http")) {
-            return;
-        }
-        if (alarmContract.getMetricContract().getDataName().equalsIgnoreCase("ping")) {
+
+        if (dataNameStr.equalsIgnoreCase("http")
+                || dataNameStr.equalsIgnoreCase("ping")
+                || dataNameStr.equalsIgnoreCase("telnet")) {
             return;
         }
 
-        if (alarmContract.getMetricContract().getDataName().equalsIgnoreCase("telnet")) {
-            return;
-        }
-
-        Optional<DataName> optionalDataName = dataNameRepository.findByName(alarmContract.getMetricContract().getDataName());
-        if (!optionalDataName.isPresent()) {
-            throw new ProtocolException(1290, "dataName not exist. " + alarmContract.getMetricContract().getDataName());
-        }
-        DataName dataName = optionalDataName.get();
+        Optional<DataName> optionalDataName = dataNameRepository.findByName(dataNameStr);
+        DataName dataName = optionalDataName.orElseThrow(() -> new ProtocolException(1290, "dataName not exist. " + dataNameStr));
         alarmContract.getMetricContract().setDataNameId(dataName.getId());
         alarmContract.getMetricContract().setDataNameContract(DataAdminService.toDataNameContract(dataName));
         alarmContract.getMetricContract().setDataSourceId(dataName.getDataSourceId());
@@ -494,6 +488,5 @@ public class AlarmAdminService implements IAlarmAdminService {
         DataSourceContract dataSourceContract = optionalDataSource.map(DataSourceTransformer::model2Contract)
             .orElseThrow(() -> new ProtocolException(1900, "dataSource not exist. id: " + dataName.getDataSourceId()));
         alarmContract.getMetricContract().setDataSourceContract(dataSourceContract);
-
     }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/AlarmAdminService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/AlarmAdminService.java
@@ -146,10 +146,7 @@ public class AlarmAdminService implements IAlarmAdminService {
     public AlarmContract findById(Long alarmId) {
         AlarmContract alarmContract = new AlarmContract();
         Optional<Alarm> optionalAlarm = alarmRepository.selectByPrimaryKey(alarmId);
-        if (!optionalAlarm.isPresent()) {
-            return null;
-        }
-        Alarm alarm = optionalAlarm.get();
+        Alarm alarm = optionalAlarm.orElseThrow(() -> new ProtocolException(404, String.format("The alarm[id=%s] not exists", alarmId)));
         alarmContract.setId(alarmId);
         alarmContract.setStatus(alarm.getStatus());
         alarmContract.setOwnerKey(alarm.getOwnerKey());

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/DataAdminService.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/service/admin/impl/DataAdminService.java
@@ -114,8 +114,11 @@ public class DataAdminService implements IDataAdminService {
     public PagerContract<DataSourceContract> findDatasource(int pageIndex, int pageSize, DataSourceType datasourceType) {
         Page page = PageHelper.startPage(pageIndex, pageSize);
         List<DataSource> list = this.dataSourceRepository.find(datasourceType);
-        return new PagerContract<>(list.stream().map(DataSourceTransformer::model2Contract).collect(Collectors.toList()), page.getPageSize(), page.getPageNum(),
-            (int)page.getTotal());
+        return new PagerContract<>(
+                list.stream()
+                        .map(i -> DataSourceTransformer.model2Contract(i, true))
+                        .collect(Collectors.toList()),
+                page.getPageSize(), page.getPageNum(), (int)page.getTotal());
     }
 
     @Override

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/AESUtils.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/AESUtils.java
@@ -4,6 +4,7 @@ import com.autohome.frostmourne.monitor.config.properties.EncryptProperties;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
@@ -11,6 +12,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
 
 /**
  * AES utils
@@ -74,6 +77,17 @@ public final class AESUtils {
             return Base64.encodeBase64String(result);
         } else {
             return new String(result, StandardCharsets.UTF_8);
+        }
+    }
+
+    public static void encryptMappingSensitive(Map<String, String> settings) {
+        try {
+            List<String> sensitiveFields = EncryptProperties.getInstance().getSensitiveFields();
+            if (!CollectionUtils.isEmpty(sensitiveFields)) {
+                sensitiveFields.forEach(field -> settings.computeIfPresent(field, (k, v) -> encrypt(v)));
+            }
+        } catch (Exception e) {
+            LOGGER.error("encryptMappingSensitive error", e);
         }
     }
 

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/AESUtils.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/tool/AESUtils.java
@@ -1,0 +1,80 @@
+package com.autohome.frostmourne.monitor.tool;
+
+import com.autohome.frostmourne.monitor.config.properties.EncryptProperties;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.*;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+/**
+ * AES utils
+ *
+ * @author limobo
+ * @since 2022/9/9 14:48
+ */
+public final class AESUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AESUtils.class);
+
+    private static final String DEFAULT_CIPHER_ALGORITHM = "SHA1PRNG";
+    private static final String KEY_ALGORITHM = "AES";
+
+    public static String encrypt(String data) {
+        try {
+            return doAES(data, Cipher.ENCRYPT_MODE);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
+            LOGGER.error("encrypt error with data: {}", data, e);
+        } catch (Exception e) {
+            LOGGER.error("encrypt exception with data: {}", data, e);
+        }
+        return null;
+    }
+
+    public static String decrypt(String data) {
+        try {
+            return doAES(data, Cipher.DECRYPT_MODE);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
+            LOGGER.error("decrypt error with data: {}", data, e);
+        } catch (Exception e) {
+            LOGGER.error("decrypt exception with data: {}", data, e);
+        }
+        return null;
+    }
+
+    private static String doAES(String data, int mode)
+            throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+
+        boolean encrypt = mode == Cipher.ENCRYPT_MODE;
+        byte[] content;
+        if (encrypt) {
+            content = data.getBytes(StandardCharsets.UTF_8);
+        } else {
+            content = Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8));
+        }
+
+        String key = EncryptProperties.getInstance().getKey();
+
+        KeyGenerator generator = KeyGenerator.getInstance(KEY_ALGORITHM);
+        SecureRandom secureRandom = SecureRandom.getInstance(DEFAULT_CIPHER_ALGORITHM);
+        secureRandom.setSeed(key.getBytes(StandardCharsets.UTF_8));
+        generator.init(128, secureRandom);
+        SecretKeySpec keySpec = new SecretKeySpec(generator.generateKey().getEncoded(), KEY_ALGORITHM);
+
+        Cipher cipher = Cipher.getInstance(KEY_ALGORITHM);
+        cipher.init(mode, keySpec);
+        byte[] result = cipher.doFinal(content);
+
+        if (encrypt) {
+            return Base64.encodeBase64String(result);
+        } else {
+            return new String(result, StandardCharsets.UTF_8);
+        }
+    }
+
+}

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
@@ -21,6 +21,17 @@ public class DataSourceTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceTransformer.class);
 
     public static DataSourceContract model2Contract(DataSource dataSource) {
+        return model2Contract(dataSource, false);
+    }
+
+    /**
+     * Encrypt DataSource sensitive fields, like username, password.
+     *
+     * @param dataSource dataSource entity
+     * @param encrypt whether to encrypt
+     * @return {@link DataSourceContract}
+     */
+    public static DataSourceContract model2Contract(DataSource dataSource, boolean encrypt) {
         DataSourceContract dataSourceContract = new DataSourceContract();
         dataSourceContract.setDatasourceName(dataSource.getDatasourceName());
         dataSourceContract.setDatasourceType(dataSource.getDatasourceType());
@@ -36,7 +47,9 @@ public class DataSourceTransformer {
                 LOGGER.error("dataSource properties json parse error, datasource: {}", dataSource, e);
             }
             // 加密敏感字段
-            handleEncryptSettings(settings);
+            if (encrypt) {
+                handleEncryptSettings(settings);
+            }
             dataSourceContract.setSettings(settings);
         } else {
             dataSourceContract.setSettings(new HashMap<>());

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
@@ -1,16 +1,24 @@
 package com.autohome.frostmourne.monitor.transform;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.autohome.frostmourne.monitor.config.properties.EncryptProperties;
 import com.autohome.frostmourne.monitor.dao.mybatis.frostmourne.domain.generate.DataSource;
+import com.autohome.frostmourne.monitor.tool.AESUtils;
 import org.elasticsearch.common.Strings;
 
 import com.autohome.frostmourne.common.jackson.JacksonUtil;
 import com.autohome.frostmourne.monitor.model.contract.DataSourceContract;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 
 public class DataSourceTransformer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceTransformer.class);
 
     public static DataSourceContract model2Contract(DataSource dataSource) {
         DataSourceContract dataSourceContract = new DataSourceContract();
@@ -19,7 +27,17 @@ public class DataSourceTransformer {
         dataSourceContract.setId(dataSource.getId());
         dataSourceContract.setServiceAddress(dataSource.getServiceAddress());
         if (!Strings.isNullOrEmpty(dataSource.getProperties())) {
-            dataSourceContract.setSettings(JacksonUtil.deSerialize(dataSource.getProperties(), new TypeReference<Map<String, String>>() {}));
+            Map<String, String> settings = new HashMap<>();
+            try {
+                settings = JacksonUtil.deSerialize(dataSource.getProperties(), new TypeReference<Map<String, String>>() {});
+            } catch (Exception e) {
+                // 当加密的key(配置 encrypt.key）发生变更后会出现原来已加密的字符串无法解密，原样输出则json解析失败
+                // 此时设置一个空的 settings，能够在"数据源"页面重新设置账号密码等信息，新的key会重新加密
+                LOGGER.error("dataSource properties json parse error, datasource: {}", dataSource, e);
+            }
+            // 加密敏感字段
+            handleEncryptSettings(settings);
+            dataSourceContract.setSettings(settings);
         } else {
             dataSourceContract.setSettings(new HashMap<>());
         }
@@ -28,5 +46,12 @@ public class DataSourceTransformer {
         dataSourceContract.setModifier(dataSource.getModifier());
         dataSourceContract.setModifyAt(dataSource.getModifyAt());
         return dataSourceContract;
+    }
+
+    private static void handleEncryptSettings(Map<String, String> settings) {
+        List<String> sensitiveFields = EncryptProperties.getInstance().getSensitiveFields();
+        if (!CollectionUtils.isEmpty(sensitiveFields)) {
+            sensitiveFields.forEach(field -> settings.computeIfPresent(field, (k, v) -> AESUtils.encrypt(v)));
+        }
     }
 }

--- a/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
+++ b/frostmourne-monitor/src/main/java/com/autohome/frostmourne/monitor/transform/DataSourceTransformer.java
@@ -48,7 +48,7 @@ public class DataSourceTransformer {
             }
             // 加密敏感字段
             if (encrypt) {
-                handleEncryptSettings(settings);
+                AESUtils.encryptMappingSensitive(settings);
             }
             dataSourceContract.setSettings(settings);
         } else {
@@ -61,10 +61,4 @@ public class DataSourceTransformer {
         return dataSourceContract;
     }
 
-    private static void handleEncryptSettings(Map<String, String> settings) {
-        List<String> sensitiveFields = EncryptProperties.getInstance().getSensitiveFields();
-        if (!CollectionUtils.isEmpty(sensitiveFields)) {
-            sensitiveFields.forEach(field -> settings.computeIfPresent(field, (k, v) -> AESUtils.encrypt(v)));
-        }
-    }
 }

--- a/frostmourne-monitor/src/main/resources/application-local.properties
+++ b/frostmourne-monitor/src/main/resources/application-local.properties
@@ -1,3 +1,7 @@
+### debug
+logging.level.com.autohome.frostmourne.monitor: debug
+logging.level.com.autohome.frostmourne.monitor.schedule: info
+
 ### initial login password
 initial_password=123456
 
@@ -35,3 +39,7 @@ your.wechat.agentid=
 your.wechat.secret=
 
 schedule_enabled=true
+
+### encryption
+encrypt_key:EX31$@*^ac1
+encrypt_sensitives:username,password

--- a/frostmourne-monitor/src/main/resources/application.properties
+++ b/frostmourne-monitor/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=10054
 logging.config=classpath:log4j2/log4j2.xml
 
+
 initial.password=${initial_password:}
 
 spring.freemarker.checkTemplateLocation=false
@@ -54,3 +55,9 @@ wechat.secret=${your.wechat.secret:}
 schedule.enabled=${schedule_enabled:true}
 schedule.trigger.pool.fast.max=200
 schedule.trigger.pool.slow.max=200
+
+### 加解密相关配置
+# 密钥，一旦设置不要轻易修改
+encrypt.key=${encrypt_key:EX31$@*^ac1}
+# 敏感字段
+encrypt.sensitives=${encrypt_sensitives:username,password}

--- a/frostmourne-vue/src/views/alarm/edit.vue
+++ b/frostmourne-vue/src/views/alarm/edit.vue
@@ -977,8 +977,8 @@ export default {
           }
           for (var j = 0; j < remoteOptions[i].dataSourceOptionList.length; j++) {
             var dataSource = {
-              label: remoteOptions[i].dataSourceOptionList[j].dataSource.datasourceName,
-              value: remoteOptions[i].dataSourceOptionList[j].dataSource.id,
+              label: remoteOptions[i].dataSourceOptionList[j].dataSourceVO.datasourceName,
+              value: remoteOptions[i].dataSourceOptionList[j].dataSourceVO.id,
               children: []
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,14 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- 公共依赖 -->
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
变更记录：

1. 对 data_source表 properties 加解密。
2. 对暴露前端的接口中， username, password 进行加密。

**对于历史数据做了兼容，有报错日志，但服务正常执行**。只有在【数据源】页面，更新 账号密码（或重新编辑下）就会自动对表里的 properties 进行加密更新，之后就不会有服务报错了。

现在逻辑：
1/ 暴露给前端的，存在敏感信息则加密 (setting里的 username, password)
2/ 服务见流转的，不加密（正常处理）
3/ 存储数据库的，properties 整体加密

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/4414032/190596935-5b8d82f7-ef13-4c56-bb24-ceb291e7b334.png">
<img width="998" alt="image" src="https://user-images.githubusercontent.com/4414032/190596968-7270d685-3af4-4bd1-9523-d1fea9c3ceae.png">
<img width="1656" alt="image" src="https://user-images.githubusercontent.com/4414032/190597592-e40f1d6f-8c82-465d-bdd4-6ee757d4dd6c.png">
<img width="1544" alt="image" src="https://user-images.githubusercontent.com/4414032/190597616-922f2196-230a-4307-ad0d-b33d88947eec.png">

